### PR TITLE
Export types

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -167,3 +167,5 @@ class Decrypter {
     return null
   }
 }
+
+export type { age, Encrypter, Decrypter }


### PR DESCRIPTION
It would be convenient if this library directly exported the types used in the public api.

If I am using this in a library that also uses some of these types in public api, declaration generation fails because the types are private.