### PR TITLE
Add CI auto-build

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,9 +16,9 @@ jobs:
           - 20.x # Active LTS as of 2024-07
           - 22.4.x # Current as of 2024-07, npm/cli#7657
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@1e31de5234b9f8995739874a8ce0492dc87873e2 # v4
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@8f152de45cc393bb48ce5d89d36b731f54556e65 # v4
         with:
           node-version: ${{ matrix.node-version }}
       - run: npm install
@@ -30,8 +30,8 @@ jobs:
   bun:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: oven-sh/setup-bun@v1
+      - uses: actions/checkout@1e31de5234b9f8995739874a8ce0492dc87873e2 # v4
+      - uses: oven-sh/setup-bun@f4d14e03ff726c06358e5557344e1da148b56cf7 # v1
         with:
           bun-version: latest
       - run: bun install

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,9 +16,9 @@ jobs:
           - 20.x # Active LTS as of 2024-07
           - 22.4.x # Current as of 2024-07, npm/cli#7657
     steps:
-      - uses: actions/checkout@1e31de5234b9f8995739874a8ce0492dc87873e2 # v4
+      - uses: actions/checkout@v4
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@8f152de45cc393bb48ce5d89d36b731f54556e65 # v4
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
       - run: npm install
@@ -30,8 +30,8 @@ jobs:
   bun:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@1e31de5234b9f8995739874a8ce0492dc87873e2 # v4
-      - uses: oven-sh/setup-bun@f4d14e03ff726c06358e5557344e1da148b56cf7 # v1
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v1
         with:
           bun-version: latest
       - run: bun install

--- a/.github/workflows/upload-release.yml
+++ b/.github/workflows/upload-release.yml
@@ -9,8 +9,8 @@ jobs:
       contents: write
       id-token: write
     steps:
-      - uses: actions/checkout@1e31de5234b9f8995739874a8ce0492dc87873e2 # v4
-      - uses: actions/setup-node@8f152de45cc393bb48ce5d89d36b731f54556e65 # v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: 20
           registry-url: 'https://registry.npmjs.org'

--- a/.github/workflows/upload-release.yml
+++ b/.github/workflows/upload-release.yml
@@ -1,0 +1,28 @@
+name: Upload standalone file to GitHub Releases
+on:
+  release:
+    types: [created]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write
+    steps:
+      - uses: actions/checkout@1e31de5234b9f8995739874a8ce0492dc87873e2 # v4
+      - uses: actions/setup-node@8f152de45cc393bb48ce5d89d36b731f54556e65 # v4
+        with:
+          node-version: 20
+          registry-url: 'https://registry.npmjs.org'
+          cache: npm
+      - run: npm install -g npm
+      - run: npm install
+      - run: npm run build
+      - run: |
+          cd tests/build
+          npm ci
+          npm run build:release
+          cd ..
+      - run: gh release upload ${{ github.event.release.tag_name }} tests/build/age.js
+        env:
+          GH_TOKEN: ${{ github.token }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 /node_modules
 /dist
 /package-lock.json
+/tests/build/age.js
+/tests/build/node_modules

--- a/tests/build/input.js
+++ b/tests/build/input.js
@@ -1,1 +1,1 @@
-export * from 'age-encryption';
+export * from "age-encryption"

--- a/tests/build/input.js
+++ b/tests/build/input.js
@@ -1,0 +1,1 @@
+export * from 'age-encryption';

--- a/tests/build/package.json
+++ b/tests/build/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "build",
+  "private": true,
+  "version": "1.0.0",
+  "main": "input.js",
+  "type": "module",
+  "devDependencies": {
+    "esbuild": "0.20.1"
+  },
+  "scripts": {
+    "build:release": "npx esbuild --bundle input.js --outfile=age.js --global-name=age"
+  },
+  "dependencies": {
+    "age-encryption": "file:../.."
+  }
+}


### PR DESCRIPTION
Add CI auto-build:

- Done in `test/build` directory using esbuild
- Whenever you create a new release in https://github.com/FiloSottile/typage/releases (takes 5 secs), it will auto-build `age.js` and upload it there
- No additional setup required

Lock CI action commits:

- Prevents supply chain attacks when git tag is replaced with another commit

Compared to 0.1.5, it's now 19x smaller:

- age-0.1.5.js: 1.46MB
    - minified: 963.3KB
    - minified + gzipped: 299.74KB
- age-noble.js: 77.73KB
    - minified: 38.5KB
    - minified + gzipped: 13.93KB