### PR TITLE
fido2prf: try to assert without a PIN first

### DIFF
--- a/fido2prf/fido2prf.go
+++ b/fido2prf/fido2prf.go
@@ -98,23 +98,38 @@ func (i *Identity) assert(nonce []byte) ([]byte, error) {
 			return nil, err
 		}
 
-		pin, err := i.getPIN()
-		if err != nil {
-			return nil, err
-		}
-
+		// Try without PIN first (for devices that handle PIN on-device).
 		assertion, err := device.Assertion(
 			i.relyingParty,
 			make([]byte, 32),
 			[][]byte{i.credentialID},
-			pin,
+			"",
 			&libfido2.AssertionOpts{
 				Extensions: []libfido2.Extension{libfido2.HMACSecretExtension},
 				HMACSalt:   hmacSecretSalt(nonce),
 				UV:         libfido2.True,
 			},
 		)
-		if err != nil {
+		if errors.Is(err, libfido2.ErrPinRequired) {
+			pin, err := i.getPIN()
+			if err != nil {
+				return nil, err
+			}
+			assertion, err = device.Assertion(
+				i.relyingParty,
+				make([]byte, 32),
+				[][]byte{i.credentialID},
+				pin,
+				&libfido2.AssertionOpts{
+					Extensions: []libfido2.Extension{libfido2.HMACSecretExtension},
+					HMACSalt:   hmacSecretSalt(nonce),
+					UV:         libfido2.True,
+				},
+			)
+		}
+		if errors.Is(err, libfido2.ErrNoCredentials) {
+			continue
+		} else if err != nil {
 			return nil, err
 		}
 


### PR DESCRIPTION
For my device that has a screen for the PIN, supplying any PIN will cause the assertion to fail, making the fido2prf plugin unusable. This PR changes the code to first try without a PIN and handling ErrPinRequired.
