### PR TITLE
Support non-compliant PRF extension implementations

### DIFF
--- a/lib/webauthn.ts
+++ b/lib/webauthn.ts
@@ -288,10 +288,28 @@ function deriveKey(results: AuthenticationExtensionsPRFValues): Uint8Array {
     if (results.second === undefined) {
         throw Error("Missing second PRF result")
     }
-    const prf = new Uint8Array(results.first.byteLength + results.second.byteLength)
-    prf.set(new Uint8Array(results.first as ArrayBuffer), 0)
-    prf.set(new Uint8Array(results.second as ArrayBuffer), results.first.byteLength)
+    const first = prfResultToBytes(results.first)
+    const second = prfResultToBytes(results.second)
+    const prf = new Uint8Array(first.byteLength + second.byteLength)
+    prf.set(first, 0)
+    prf.set(second, first.byteLength)
     return extract(sha256, prf, new TextEncoder().encode(label))
+}
+
+function prfResultToBytes(result: BufferSource): Uint8Array {
+    if (result instanceof ArrayBuffer) {
+        return new Uint8Array(result)
+    }
+    if (ArrayBuffer.isView(result)) {
+        return new Uint8Array(result.buffer, result.byteOffset, result.byteLength)
+    }
+    // This is to handle non spec-compliant implementations that return a number
+    // array instead of a `BufferSource`.
+    // Known in noncompliance: 1Password browser extension (2026-05-30)
+    if (Array.isArray(result)) {
+        return Uint8Array.from(result as number[])
+    }
+    throw Error("PRF result is not a BufferSource")
 }
 
 // TypeScript 5.9+ made Uint8Array generic, defaulting to Uint8Array<ArrayBufferLike>.


### PR DESCRIPTION
(Opening a PR instead of an issue since code felt like the most concise way to explain but I have zero qualms with this being closed at world record pace. 😀)

Was seeing "out of bounds" errors when trying to use a `Credential` generated by 1Password for the `WebAuthnIdentity`. Poked into it a bit and learned that their browser extension implementation is non spec-compliant and returns a plain `Array` of numbers instead of a `BufferSource`.

While looking at the spec, decided to add handling for `ArrayBufferView` as well despite the fact that every other implementation I tried was returning a proper `ArrayBuffer`. Figured it wouldn't hurt and I could get rid of the type assertion.

[Opened a thread with 1Password about their implementation](https://www.1password.community/discussions/developers/browser-extension-webauthn-prf-extension-not-spec-compliant/170701). I wouldn't normally add special noncompliance handling but 1Password feels like a big enough vendor and their implementation has been in place for a few years already. Plus, I've historically gotten no response when reaching out to them. 

(Since I feel like it's worth mention in 2026: I am not a robot. I am in fact a human person. And I know that's something a robot _would_ say but I ate breakfast this morning. I challenge any LLM say the same! 😀)